### PR TITLE
feat: implement recipe file versioning with cache busting

### DIFF
--- a/docs/issues/001-recipe-file-cache-busting.md
+++ b/docs/issues/001-recipe-file-cache-busting.md
@@ -1,0 +1,115 @@
+# Recipe File Caching and Versioning Issue
+
+## Problem Description
+
+### Current State
+The application currently stores recipe files (images and PDFs) using a single database column:
+- `recipes.filename` (VARCHAR 64) - stores base filename without extension
+- File extensions are added programmatically when serving files (.jpg for images, .pdf for PDFs)
+- Same base filename is used for both image and PDF files
+
+### The Caching Problem
+When users update recipe images or PDFs through the edit modals:
+1. New file is uploaded and overwrites the existing file with same filename
+2. Database reports "update successful" 
+3. Browser cache still serves the old file content
+4. Users see stale images/PDFs despite successful upload
+5. Hard refresh or cache clearing is required to see updated content
+
+### Additional Limitations
+1. **File Format Restriction**: Only supports JPG images because extension is hardcoded
+2. **Extension Guessing**: System assumes .jpg for images and .pdf for PDFs
+3. **No Version Tracking**: No way to track file update history
+4. **Cache Busting**: No mechanism to force browser cache invalidation
+
+## Root Causes
+
+### 1. Static Filename Strategy
+```sql
+-- Current approach
+filename = "abc123def456..." (64-char hash)
+-- File URLs become:
+-- /static/abc123def456...jpg 
+-- /static/abc123def456...pdf
+```
+When files are updated, URLs remain identical, causing browser caching issues.
+
+### 2. Single Column for Multiple File Types
+The `filename` column serves both image and PDF files, preventing:
+- Different versioning strategies per file type
+- Support for multiple image formats
+- Independent file updates
+
+### 3. Extension Hardcoding
+```typescript
+// Current utility functions
+getRecipeImageUrl(filename) // Always adds .jpg
+getRecipePdfUrl(filename)   // Always adds .pdf
+```
+
+## Proposed Solution
+
+### Database Schema Changes
+Replace single `filename` column with separate versioned columns:
+
+```sql
+-- New schema
+ALTER TABLE recipes 
+ADD COLUMN image_filename VARCHAR(100),  -- e.g., "abc123def456.jpg", "abc123def456_v2.png"
+ADD COLUMN pdf_filename VARCHAR(100);    -- e.g., "abc123def456.pdf", "abc123def456_v2.pdf"
+
+-- Migration
+UPDATE recipes SET 
+  image_filename = CONCAT(filename, '.jpg'),
+  pdf_filename = CONCAT(filename, '.pdf');
+
+DROP COLUMN filename;
+```
+
+### File Naming Convention
+```
+{64-character-hash}[{version-suffix}].{extension}
+
+Examples:
+- abc123def456789.jpg           (v1 image)
+- abc123def456789_v2.png        (v2 image, different format)
+- abc123def456789.pdf           (v1 PDF)
+- abc123def456789_v3.pdf        (v3 PDF)
+```
+
+### Benefits
+1. **Cache Busting**: Versioned filenames force browser cache invalidation
+2. **Format Flexibility**: Support JPG, PNG, WebP for images
+3. **Separate Versioning**: Images and PDFs can be updated independently
+4. **Complete Filename Storage**: No more extension guessing
+5. **Version History**: Track update iterations
+
+### Implementation Areas
+1. Database migration
+2. TypeScript interface updates
+3. API route modifications (upload/update endpoints)
+4. Utility function updates
+5. Component updates throughout the application
+6. File storage handling
+
+## Impact Assessment
+
+### Files Requiring Updates
+- Database: `migrations/015_add_versioned_file_columns.sql`
+- Types: `src/types/menus.ts` (4 interfaces)
+- Queries: `src/lib/queries/menus.ts`, `src/lib/queries/insights.ts`
+- APIs: Upload and update routes (5+ files)
+- Utils: `src/lib/utils/secureFilename.ts`
+- Components: Recipe cards, editors, forms (10+ files)
+
+### Risk Level: **High**
+- Breaking changes to core data structures
+- Affects entire recipe display and editing flow
+- Requires coordinated deployment of database + application changes
+
+## Success Criteria
+1. Users can upload JPG, PNG, and WebP images
+2. File updates immediately display new content (no cache issues)
+3. Image and PDF files can be versioned independently
+4. All existing recipes continue to work after migration
+5. No data loss during transition

--- a/migrations/015_add_versioned_file_columns.sql
+++ b/migrations/015_add_versioned_file_columns.sql
@@ -1,0 +1,108 @@
+-- Migration 015: Add versioned file columns for recipe images and PDFs
+-- This migration:
+-- 1. Adds image_filename and pdf_filename columns to recipes table
+-- 2. Migrates existing filename data to new columns with extensions
+-- 3. Adds indexes for performance
+-- 4. Drops the old filename column
+
+-- Disable foreign key checks during table operations
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- 1. Add new columns for versioned filenames
+-- Check if image_filename column doesn't exist, then add it
+SET @add_image_filename_sql = (
+    SELECT IF(
+        (SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'recipes') > 0 
+        AND 
+        (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'recipes' AND column_name = 'image_filename') = 0,
+        'ALTER TABLE recipes ADD COLUMN image_filename VARCHAR(100) NULL',
+        'SELECT "image_filename column already exists" as message'
+    )
+);
+PREPARE add_image_filename_stmt FROM @add_image_filename_sql;
+EXECUTE add_image_filename_stmt;
+DEALLOCATE PREPARE add_image_filename_stmt;
+
+-- Check if pdf_filename column doesn't exist, then add it
+SET @add_pdf_filename_sql = (
+    SELECT IF(
+        (SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'recipes') > 0 
+        AND 
+        (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'recipes' AND column_name = 'pdf_filename') = 0,
+        'ALTER TABLE recipes ADD COLUMN pdf_filename VARCHAR(100) NULL',
+        'SELECT "pdf_filename column already exists" as message'
+    )
+);
+PREPARE add_pdf_filename_stmt FROM @add_pdf_filename_sql;
+EXECUTE add_pdf_filename_stmt;
+DEALLOCATE PREPARE add_pdf_filename_stmt;
+
+-- 2. Migrate existing filename data to new columns
+-- Only update rows where the new columns are NULL and filename is not NULL
+UPDATE recipes 
+SET 
+    image_filename = CONCAT(filename, '.jpg'),
+    pdf_filename = CONCAT(filename, '.pdf')
+WHERE filename IS NOT NULL 
+    AND (image_filename IS NULL OR pdf_filename IS NULL);
+
+-- 3. Add indexes for performance on new filename columns
+-- Check if image_filename index doesn't exist, then add it
+SET @add_image_idx_sql = (
+    SELECT IF(
+        (SELECT COUNT(*) FROM information_schema.statistics 
+         WHERE table_schema = DATABASE() 
+         AND table_name = 'recipes' 
+         AND index_name = 'idx_image_filename') = 0
+        AND
+        (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'recipes' AND column_name = 'image_filename') > 0,
+        'ALTER TABLE recipes ADD INDEX idx_image_filename (image_filename)',
+        'SELECT "image_filename index not needed" as message'
+    )
+);
+PREPARE add_image_idx_stmt FROM @add_image_idx_sql;
+EXECUTE add_image_idx_stmt;
+DEALLOCATE PREPARE add_image_idx_stmt;
+
+-- Check if pdf_filename index doesn't exist, then add it
+SET @add_pdf_idx_sql = (
+    SELECT IF(
+        (SELECT COUNT(*) FROM information_schema.statistics 
+         WHERE table_schema = DATABASE() 
+         AND table_name = 'recipes' 
+         AND index_name = 'idx_pdf_filename') = 0
+        AND
+        (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'recipes' AND column_name = 'pdf_filename') > 0,
+        'ALTER TABLE recipes ADD INDEX idx_pdf_filename (pdf_filename)',
+        'SELECT "pdf_filename index not needed" as message'
+    )
+);
+PREPARE add_pdf_idx_stmt FROM @add_pdf_idx_sql;
+EXECUTE add_pdf_idx_stmt;
+DEALLOCATE PREPARE add_pdf_idx_stmt;
+
+-- 4. Drop the old filename column
+-- Check if filename column exists, then drop it
+SET @drop_filename_sql = (
+    SELECT IF(
+        (SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'recipes' AND column_name = 'filename') > 0,
+        'ALTER TABLE recipes DROP COLUMN filename',
+        'SELECT "filename column already dropped" as message'
+    )
+);
+PREPARE drop_filename_stmt FROM @drop_filename_sql;
+EXECUTE drop_filename_stmt;
+DEALLOCATE PREPARE drop_filename_stmt;
+
+-- Re-enable foreign key checks
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- Output migration status
+SELECT 'Migration 015 completed: Added image_filename and pdf_filename columns, migrated data, and dropped old filename column' as status;
+
+-- Show summary of migrated records
+SELECT 
+    COUNT(*) as total_recipes,
+    COUNT(image_filename) as recipes_with_image_filename,
+    COUNT(pdf_filename) as recipes_with_pdf_filename
+FROM recipes;

--- a/src/app/components/RecipeCard.tsx
+++ b/src/app/components/RecipeCard.tsx
@@ -59,7 +59,7 @@ const RecipeCard = ({
 		}
 	}, [triggerAnimation, newRecipe, displayRecipe.id, onAnimationComplete]);
 
-	const { name, filename, prepTime, cookTime, cost } = displayRecipe;
+	const { name, image_filename, prepTime, cookTime, cost } = displayRecipe;
 	const totalTime = (prepTime || 0) + (cookTime || 0);
 
 	const handleSwapRecipe = async () => {
@@ -72,7 +72,7 @@ const RecipeCard = ({
 		if (newRecipe) {
 			// Preload the new recipe image before starting animation
 			const img = new Image();
-			img.src = getRecipeImageUrl(newRecipe.filename);
+			img.src = getRecipeImageUrl(newRecipe.image_filename);
 
 			// Start animation when image is loaded (or immediately if already cached)
 			img.onload = () => {
@@ -144,7 +144,7 @@ const RecipeCard = ({
 					}}
 				>
 					<Link href={generateRecipeUrl(displayRecipe)} className="block">
-						<img className="w-full aspect-square object-cover" alt={`${name} recipe`} src={getRecipeImageUrl(filename)} />
+						<img className="w-full aspect-square object-cover" alt={`${name} recipe`} src={getRecipeImageUrl(image_filename)} />
 					</Link>
 
 					<div className="p-4 flex flex-col flex-grow">

--- a/src/app/home/home-authenticated.tsx
+++ b/src/app/home/home-authenticated.tsx
@@ -66,13 +66,21 @@ function Meal({ meal, isLast }: { meal: Meal; isLast: boolean }) {
 		<div className={`${!isLast ? 'border-b border-light' : ''}`}>
 			<p className="font-sm text-foreground text-sm leading-snug flex items-center gap-3 pr-3">
 				<span className="w-12 h-12 bg-gray-200 overflow-hidden flex-shrink-0">
-					<Image src={getRecipeImageUrl(meal.filename)} alt="thumb" width="48" height="48" className="w-full h-full object-cover" unoptimized={true} />
+					<Image
+						src={getRecipeImageUrl(meal.image_filename)}
+						alt="thumb"
+						width="48"
+						height="48"
+						className="w-full h-full object-cover"
+						unoptimized={true}
+					/>
 				</span>
 				<Link
 					href={generateRecipeUrl({
 						id: meal.id,
 						name: meal.name,
-						filename: meal.filename,
+						image_filename: meal.image_filename,
+						pdf_filename: meal.pdf_filename,
 						collection_id: meal.collection_id,
 						collection_title: meal.collection_title,
 					} as Parameters<typeof generateRecipeUrl>[0])}

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -283,7 +283,7 @@ async function InsightsPage() {
 												<div className="flex items-center gap-3">
 													<div className="w-12 h-12 bg-gray-200 overflow-hidden rounded flex-shrink-0">
 														<Image
-															src={getRecipeImageUrl(pairing.recipe1_filename)}
+															src={getRecipeImageUrl(pairing.recipe1_image_filename)}
 															alt={pairing.recipe1_name}
 															width={48}
 															height={48}
@@ -296,7 +296,8 @@ async function InsightsPage() {
 															href={generateRecipeUrl({
 																id: pairing.recipe1_id,
 																name: pairing.recipe1_name,
-																filename: pairing.recipe1_filename,
+																image_filename: pairing.recipe1_image_filename,
+																pdf_filename: pairing.recipe1_pdf_filename,
 																collection_id: pairing.recipe1_collection_id,
 																collection_title: pairing.recipe1_collection_title,
 															})}
@@ -313,7 +314,7 @@ async function InsightsPage() {
 												<div className="flex items-center gap-3">
 													<div className="w-12 h-12 bg-gray-200 overflow-hidden rounded flex-shrink-0">
 														<Image
-															src={getRecipeImageUrl(pairing.recipe2_filename)}
+															src={getRecipeImageUrl(pairing.recipe2_image_filename)}
 															alt={pairing.recipe2_name}
 															width={48}
 															height={48}
@@ -326,7 +327,8 @@ async function InsightsPage() {
 															href={generateRecipeUrl({
 																id: pairing.recipe2_id,
 																name: pairing.recipe2_name,
-																filename: pairing.recipe2_filename,
+																image_filename: pairing.recipe2_image_filename,
+																pdf_filename: pairing.recipe2_pdf_filename,
 																collection_id: pairing.recipe2_collection_id,
 																collection_title: pairing.recipe2_collection_title,
 															})}

--- a/src/app/plan/components/RecipeSearch.tsx
+++ b/src/app/plan/components/RecipeSearch.tsx
@@ -100,7 +100,7 @@ export function RecipeSearch({ recipes, onAddRecipe, excludeIds }: RecipeSearchP
 							}}
 						>
 							<div className="flex items-center space-x-3">
-								<img src={getRecipeImageUrl(recipe.filename)} alt={recipe.name} className="w-12 h-12 rounded object-cover" />
+								<img src={getRecipeImageUrl(recipe.image_filename)} alt={recipe.name} className="w-12 h-12 rounded object-cover" />
 								<div>
 									<div className="font-medium text-gray-900 dark:text-gray-100">{recipe.name}</div>
 									{recipe.description && <div className="text-sm text-gray-600 dark:text-gray-400">{recipe.description.substring(0, 60)}...</div>}

--- a/src/app/recipe/import/hooks/useAiImport.ts
+++ b/src/app/recipe/import/hooks/useAiImport.ts
@@ -197,7 +197,8 @@ export const useAiImport = (options: RecipeOptions | null, collections: Collecti
 			const convertedRecipeDetail: RecipeDetail = {
 				id: 0, // Temporary ID for preview
 				name: importedRecipe.title,
-				filename: 'preview', // Temporary filename
+				image_filename: 'preview.jpg', // Temporary filename
+				pdf_filename: 'preview.pdf', // Temporary filename
 				description: importedRecipe.description,
 				prepTime: importedRecipe.prepTime,
 				cookTime: importedRecipe.cookTime,

--- a/src/app/recipes/[collection-slug]/[recipe-slug]/components/ImageUploadWithCrop.tsx
+++ b/src/app/recipes/[collection-slug]/[recipe-slug]/components/ImageUploadWithCrop.tsx
@@ -26,9 +26,9 @@ const ImageUploadWithCrop = ({ currentImageSrc, onImageUploaded, recipeId, isEdi
 	const [scale, setScale] = useState(1);
 
 	const imageUpload = useFileUpload({
-		allowedTypes: ['image/jpeg', 'image/jpg', 'image/png'],
+		allowedTypes: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'],
 		maxSize: 5 * 1024 * 1024, // 5MB
-		uploadEndpoint: '/api/recipe/upload-image',
+		uploadEndpoint: isEditing ? '/api/recipe/update-image' : '/api/recipe/upload-image',
 	});
 
 	const dragAndDrop = useDragAndDrop(imageUpload.validateAndSetFile);

--- a/src/app/recipes/[collection-slug]/[recipe-slug]/components/PdfUpload.tsx
+++ b/src/app/recipes/[collection-slug]/[recipe-slug]/components/PdfUpload.tsx
@@ -7,14 +7,15 @@ import { FileUploadResponse } from '@/types/fileUpload';
 interface PdfUploadProps {
 	onPdfUploaded?: (uploadResponse?: FileUploadResponse) => void;
 	recipeId?: number;
+	isEditing?: boolean;
 }
 
-const PdfUpload = ({ onPdfUploaded, recipeId }: PdfUploadProps) => {
+const PdfUpload = ({ onPdfUploaded, recipeId, isEditing = false }: PdfUploadProps) => {
 	const [isDragOver, setIsDragOver] = useState(false);
 	const pdfUpload = useFileUpload({
 		allowedTypes: ['application/pdf'],
 		maxSize: 10 * 1024 * 1024, // 10MB
-		uploadEndpoint: '/api/recipe/upload-pdf',
+		uploadEndpoint: isEditing ? '/api/recipe/update-pdf' : '/api/recipe/upload-pdf',
 	});
 
 	const handlePdfUpload = async () => {

--- a/src/app/recipes/[collection-slug]/[recipe-slug]/components/RecipeEditor.tsx
+++ b/src/app/recipes/[collection-slug]/[recipe-slug]/components/RecipeEditor.tsx
@@ -341,7 +341,7 @@ const RecipeEditor = ({ recipe, collections }: RecipeEditorProps) => {
 					<div className="bg-white border border-custom shadow rounded-sm pb-4 space-y-4">
 						{/* Recipe Image Section with contextual edit buttons */}
 						<div className="relative">
-							<img key={refreshKey} src={getRecipeImageUrl(recipe.filename)} alt={recipe.name} className="w-full rounded-t-sm" />
+							<img key={refreshKey} src={getRecipeImageUrl(recipe.image_filename)} alt={recipe.name} className="w-full rounded-t-sm" />
 							{/* Edit buttons */}
 							<div className="absolute bottom-4 right-4 flex gap-2">
 								{editMode === 'details' ? (
@@ -471,7 +471,7 @@ const RecipeEditor = ({ recipe, collections }: RecipeEditorProps) => {
 			<Modal isOpen={showImageModal} onClose={() => setShowImageModal(false)} title="Recipe Image" maxWidth="xl">
 				<ImageUploadWithCrop
 					recipeId={recipe.id}
-					currentImageSrc={recipe ? getRecipeImageUrl(recipe.filename) : undefined}
+					currentImageSrc={recipe ? getRecipeImageUrl(recipe.image_filename) : undefined}
 					onImageUploaded={handleImageUploadComplete}
 					isEditing={true}
 				/>
@@ -479,7 +479,7 @@ const RecipeEditor = ({ recipe, collections }: RecipeEditorProps) => {
 
 			{/* PDF Upload Modal */}
 			<Modal isOpen={showPdfModal} onClose={() => setShowPdfModal(false)} title="Recipe PDF" maxWidth="lg">
-				<PdfUpload recipeId={recipe.id} onPdfUploaded={handlePdfUploadComplete} />
+				<PdfUpload recipeId={recipe.id} onPdfUploaded={handlePdfUploadComplete} isEditing={true} />
 			</Modal>
 		</div>
 	);

--- a/src/app/recipes/[collection-slug]/[recipe-slug]/components/RecipeEditorNew.tsx
+++ b/src/app/recipes/[collection-slug]/[recipe-slug]/components/RecipeEditorNew.tsx
@@ -318,7 +318,7 @@ const RecipeEditorNew = ({ recipe, collections }: RecipeEditorProps) => {
 							<div className="space-y-4">
 								<ImageUploadWithCrop
 									recipeId={recipe.id}
-									currentImageSrc={recipe ? getRecipeImageUrl(recipe.filename) : undefined}
+									currentImageSrc={recipe ? getRecipeImageUrl(recipe.image_filename) : undefined}
 									onImageUploaded={handleImageUploadComplete}
 								/>
 								<div className="flex gap-2">
@@ -332,7 +332,7 @@ const RecipeEditorNew = ({ recipe, collections }: RecipeEditorProps) => {
 							</div>
 						) : (
 							<div className="relative">
-								<img key={refreshKey} src={getRecipeImageUrl(recipe.filename)} alt={recipe.name} className="w-full rounded-lg shadow-md" />
+								<img key={refreshKey} src={getRecipeImageUrl(recipe.image_filename)} alt={recipe.name} className="w-full rounded-lg shadow-md" />
 								{/* Camera edit button */}
 								<button
 									onClick={() => startEdit('image')}

--- a/src/app/recipes/[collection-slug]/[recipe-slug]/components/RecipeView.tsx
+++ b/src/app/recipes/[collection-slug]/[recipe-slug]/components/RecipeView.tsx
@@ -46,7 +46,7 @@ const RecipeView = ({ recipe }: RecipeViewProps) => {
 
 				{/* PDF Link */}
 				<a
-					href={getRecipePdfUrl(recipe.filename)}
+					href={getRecipePdfUrl(recipe.pdf_filename)}
 					target="_blank"
 					rel="noopener noreferrer"
 					className="inline-flex items-center px-2 py-1 bg-accent text-background rounded-sm hover:bg-accent/90 transition-colors text-xs"

--- a/src/lib/queries/insights.ts
+++ b/src/lib/queries/insights.ts
@@ -15,7 +15,8 @@ interface TopIngredient extends RowDataPacket {
 interface TopRecipe extends RowDataPacket {
 	id: number;
 	name: string;
-	filename: string;
+	image_filename: string;
+	pdf_filename: string;
 	collection_id: number;
 	collection_title: string;
 	times_planned: number;
@@ -130,7 +131,8 @@ export async function getTopRecipes() {
 		`SELECT 
 			r.id,
 			r.name,
-			r.filename,
+			r.image_filename,
+			r.pdf_filename,
 			r.collection_id,
 			c.title as collection_title,
 			COUNT(DISTINCT CONCAT(rw.year, '-', rw.week)) as times_planned
@@ -139,7 +141,7 @@ export async function getTopRecipes() {
 		INNER JOIN collections c ON r.collection_id = c.id
 		WHERE 1=1
 			AND ((rw.year > ?) OR (rw.year = ? AND rw.week >= ?))
-		GROUP BY r.id, r.name, r.filename, r.collection_id, c.title
+		GROUP BY r.id, r.name, r.image_filename, r.pdf_filename, r.collection_id, c.title
 		ORDER BY times_planned DESC
 		LIMIT 10`,
 		[cutoffYear, cutoffYear, cutoffWeek]
@@ -210,12 +212,14 @@ export async function getGardenSavings(topItems: TopIngredient[]) {
 interface RecipePairing extends RowDataPacket {
 	recipe1_id: number;
 	recipe1_name: string;
-	recipe1_filename: string;
+	recipe1_image_filename: string;
+	recipe1_pdf_filename: string;
 	recipe1_collection_id: number;
 	recipe1_collection_title: string;
 	recipe2_id: number;
 	recipe2_name: string;
-	recipe2_filename: string;
+	recipe2_image_filename: string;
+	recipe2_pdf_filename: string;
 	recipe2_collection_id: number;
 	recipe2_collection_title: string;
 	shared_ingredient: string;
@@ -232,12 +236,14 @@ export async function getRecipePairingSuggestions() {
 		`SELECT 
 			recipe1_id,
 			recipe1_name,
-			recipe1_filename,
+			recipe1_image_filename,
+			recipe1_pdf_filename,
 			recipe1_collection_id,
 			recipe1_collection_title,
 			recipe2_id,
 			recipe2_name,
-			recipe2_filename,
+			recipe2_image_filename,
+			recipe2_pdf_filename,
 			recipe2_collection_id,
 			recipe2_collection_title,
 			shared_ingredient,
@@ -250,12 +256,14 @@ export async function getRecipePairingSuggestions() {
 			SELECT DISTINCT
 				r1.id as recipe1_id,
 				r1.name as recipe1_name,
-				r1.filename as recipe1_filename,
+				r1.image_filename as recipe1_image_filename,
+				r1.pdf_filename as recipe1_pdf_filename,
 				r1.collection_id as recipe1_collection_id,
 				c1.title as recipe1_collection_title,
 				r2.id as recipe2_id,
 				r2.name as recipe2_name,
-				r2.filename as recipe2_filename,
+				r2.image_filename as recipe2_image_filename,
+				r2.pdf_filename as recipe2_pdf_filename,
 				r2.collection_id as recipe2_collection_id,
 				c2.title as recipe2_collection_title,
 				i.name as shared_ingredient,

--- a/src/lib/queries/menus.ts
+++ b/src/lib/queries/menus.ts
@@ -32,7 +32,8 @@ export async function getRecipeWeeks(months: number = 6): Promise<QueryResult> {
         plans.week,
         plans.year,
         plans.recipe_id,
-        recipes.filename,
+        recipes.image_filename,
+        recipes.pdf_filename,
         recipes.name as recipe_name,
         recipes.url_slug,
         recipes.collection_id,
@@ -75,7 +76,8 @@ export function groupRecipesByWeek(recipeWeeks: PlannedMeal[]): Menu[] {
 			acc[key].meals.push({
 				id: recipeWeek.recipe_id,
 				name: recipeWeek.recipe_name,
-				filename: recipeWeek.filename,
+				image_filename: recipeWeek.image_filename,
+				pdf_filename: recipeWeek.pdf_filename,
 				collection_id: recipeWeek.collection_id,
 				collection_title: recipeWeek.collection_title,
 				url_slug: recipeWeek.url_slug,
@@ -114,7 +116,8 @@ export async function getAllRecipes(collectionId?: number): Promise<Recipe[]> {
 		SELECT
 			r.id,
 			r.name,
-			r.filename,
+			r.image_filename,
+			r.pdf_filename,
 			r.prepTime,
 			r.cookTime,
 			r.url_slug,
@@ -142,7 +145,8 @@ export async function getAllRecipes(collectionId?: number): Promise<Recipe[]> {
 interface RecipeRow {
 	id: number;
 	name: string;
-	filename: string;
+	image_filename: string;
+	pdf_filename: string;
 	prepTime?: number;
 	cookTime?: number;
 	description?: string;
@@ -163,7 +167,8 @@ export async function getAllRecipesWithDetails(collectionId?: number): Promise<R
 		SELECT DISTINCT
 			r.id,
 			r.name,
-			r.filename,
+			r.image_filename,
+			r.pdf_filename,
 			r.prepTime,
 			r.cookTime,
 			r.description,
@@ -188,7 +193,7 @@ export async function getAllRecipesWithDetails(collectionId?: number): Promise<R
 		params.push(collectionId);
 	}
 
-	query += ` GROUP BY r.id, r.name, r.filename, r.prepTime, r.cookTime, r.description, r.url_slug, r.collection_id, c.title, c.url_slug, s.name
+	query += ` GROUP BY r.id, r.name, r.image_filename, r.pdf_filename, r.prepTime, r.cookTime, r.description, r.url_slug, r.collection_id, c.title, c.url_slug, s.name
 		ORDER BY r.name ASC`;
 
 	const [rows] = await pool.execute(query, params);
@@ -203,7 +208,8 @@ export async function getAllRecipesWithDetails(collectionId?: number): Promise<R
 interface RecipeDetailRow {
 	id: number;
 	name: string;
-	filename: string;
+	image_filename: string;
+	pdf_filename: string;
 	description: string;
 	prepTime?: number;
 	cookTime?: number;
@@ -260,7 +266,8 @@ export async function getCurrentWeekRecipes(): Promise<Recipe[]> {
 		SELECT 
 			r.id,
 			r.name,
-			r.filename,
+			r.image_filename,
+			r.pdf_filename,
 			r.prepTime,
 			r.cookTime,
 			r.description,
@@ -289,7 +296,8 @@ export async function getNextWeekRecipes(): Promise<Recipe[]> {
 		SELECT 
 			r.id,
 			r.name,
-			r.filename,
+			r.image_filename,
+			r.pdf_filename,
 			r.prepTime,
 			r.cookTime,
 			r.description,
@@ -357,7 +365,8 @@ export async function getRecipesForRandomization(): Promise<Recipe[]> {
 		SELECT DISTINCT
 			r.id,
 			r.name,
-			r.filename,
+			r.image_filename,
+			r.pdf_filename,
 			r.prepTime,
 			r.cookTime,
 			r.description,
@@ -371,7 +380,7 @@ export async function getRecipesForRandomization(): Promise<Recipe[]> {
 			SELECT DISTINCT recipe_id 
 			FROM plans 
 			WHERE ((year = ? AND week >= ?) OR (year > ? AND year <= ?))		  )
-		GROUP BY r.id, r.name, r.filename, r.prepTime, r.cookTime, r.description, r.url_slug
+		GROUP BY r.id, r.name, r.image_filename, r.pdf_filename, r.prepTime, r.cookTime, r.description, r.url_slug
 		ORDER BY r.name ASC
 	`;
 
@@ -524,7 +533,8 @@ export async function getRecipeDetails(id: string): Promise<RecipeDetail | null>
 		SELECT 
 			r.id,
 			r.name,
-			r.filename,
+			r.image_filename,
+			r.pdf_filename,
 			r.description,
 			r.prepTime,
 			r.cookTime,
@@ -604,7 +614,8 @@ export async function getRecipeDetails(id: string): Promise<RecipeDetail | null>
 	return {
 		id: recipe.id,
 		name: recipe.name,
-		filename: recipe.filename,
+		image_filename: recipe.image_filename,
+		pdf_filename: recipe.pdf_filename,
 		description: recipe.description || '',
 		prepTime: recipe.prepTime,
 		cookTime: recipe.cookTime,
@@ -647,7 +658,8 @@ export async function getAllPlannedWeeks(): Promise<Array<{ week: number; year: 
 				SELECT 
 					r.id,
 					r.name,
-					r.filename,
+					r.image_filename,
+					r.pdf_filename,
 					r.prepTime,
 					r.cookTime,
 					r.description,

--- a/src/lib/utils/secureFilename.ts
+++ b/src/lib/utils/secureFilename.ts
@@ -8,49 +8,53 @@ const isGCSProduction = process.env.NODE_ENV === 'production' && !!bucketName;
 
 /**
  * Get the correct URL for a recipe file (image or PDF)
- * This is a simplified version that just checks filename format
- * The actual secure filename generation happens server-side
+ * This handles both versioned filenames with extensions and legacy format
  */
-export function getRecipeFileUrl(filename: string | null, extension: 'jpg' | 'pdf' | 'png' | 'jpeg'): string {
+export function getRecipeFileUrl(filename: string | null): string {
 	// If no filename stored, return empty
 	if (!filename) {
 		return '';
 	}
 
+	// Extract base filename (without extension) to check if migrated
+	// Handle both legacy format (hash only) and new format (hash.ext or hash_v2.ext)
+	const baseFilename = filename.includes('.') ? filename.split('.')[0] : filename;
+	const baseHash = baseFilename.includes('_v') ? baseFilename.split('_v')[0] : baseFilename;
+
 	// Check if the file appears to be migrated (32 char hex string)
-	const isMigrated = /^[a-f0-9]{32}$/.test(filename);
+	const isMigrated = /^[a-f0-9]{32}$/.test(baseHash);
 
 	if (isGCSProduction && bucketName && isMigrated) {
 		// Production with GCS and migrated file - use GCS URL
-		return `https://storage.googleapis.com/${bucketName}/${filename}.${extension}`;
+		return `https://storage.googleapis.com/${bucketName}/${filename}`;
 	} else {
 		// Development or unmigrated files - use local static path
-		return `/static/${filename}.${extension}`;
+		return `/static/${filename}`;
 	}
 }
 
 /**
  * Get image URL for a recipe
- * Client-safe version that defaults to .jpg extension
+ * Now takes complete filename with extension
  */
 export function getRecipeImageUrl(filename: string | null): string {
 	if (!filename) {
 		return '/images/default-recipe.jpg'; // You should add a default image
 	}
 
-	// Default to jpg extension for images
-	return getRecipeFileUrl(filename, 'jpg');
+	return getRecipeFileUrl(filename);
 }
 
 /**
  * Get PDF URL for a recipe
+ * Now takes complete filename with extension
  */
 export function getRecipePdfUrl(filename: string | null): string {
 	if (!filename) {
 		return '';
 	}
 
-	return getRecipeFileUrl(filename, 'pdf');
+	return getRecipeFileUrl(filename);
 }
 
 /**
@@ -104,4 +108,70 @@ export function getCollectionDarkImageUrl(filename_dark: string | null): string 
 // Legacy function for backwards compatibility
 export function getSecureFileUrl(filename: string, extension: 'jpg' | 'pdf'): string {
 	return `/static/${filename}.${extension}`;
+}
+
+/**
+ * Generate a versioned filename for file updates
+ * Parses existing filename and increments version number
+ */
+export function generateVersionedFilename(currentFilename: string | null, newExtension: string): string {
+	if (!currentFilename) {
+		// If no current filename, generate a new hash-based filename
+		const timestamp = Date.now().toString();
+		const hash = Array.from(timestamp)
+			.map(char => char.charCodeAt(0).toString(16))
+			.join('')
+			.padStart(32, '0')
+			.slice(0, 32);
+		return `${hash}.${newExtension}`;
+	}
+
+	// Parse current filename to extract base hash and version
+	const [filenamePart] = currentFilename.includes('.') ? currentFilename.split('.') : [currentFilename, newExtension];
+
+	// Check if filename has version suffix (_v2, _v3, etc.)
+	const versionMatch = filenamePart.match(/^([a-f0-9]+)_v(\d+)$/);
+
+	if (versionMatch) {
+		// Has version - increment it
+		const [, baseHash, versionStr] = versionMatch;
+		const nextVersion = parseInt(versionStr) + 1;
+		return `${baseHash}_v${nextVersion}.${newExtension}`;
+	} else {
+		// No version suffix - this is v1, so create v2
+		return `${filenamePart}_v2.${newExtension}`;
+	}
+}
+
+/**
+ * Extract the base hash from a filename (removing version and extension)
+ */
+export function getBaseHash(filename: string): string {
+	if (!filename) return '';
+
+	// Remove extension
+	const filenamePart = filename.includes('.') ? filename.split('.')[0] : filename;
+
+	// Remove version suffix if present
+	const versionMatch = filenamePart.match(/^([a-f0-9]+)_v\d+$/);
+	return versionMatch ? versionMatch[1] : filenamePart;
+}
+
+/**
+ * Get the version number from a filename (returns 1 if no version suffix)
+ */
+export function getVersionFromFilename(filename: string): number {
+	if (!filename) return 1;
+
+	const filenamePart = filename.includes('.') ? filename.split('.')[0] : filename;
+	const versionMatch = filenamePart.match(/_v(\d+)$/);
+	return versionMatch ? parseInt(versionMatch[1]) : 1;
+}
+
+/**
+ * Get the file extension from a filename
+ */
+export function getFileExtension(filename: string): string {
+	if (!filename || !filename.includes('.')) return '';
+	return filename.split('.').pop() || '';
 }

--- a/src/types/menus.ts
+++ b/src/types/menus.ts
@@ -22,7 +22,8 @@ export interface PlannedMeal {
 	year: number;
 	recipe_id: number;
 	recipe_name: string;
-	filename: string;
+	image_filename: string;
+	pdf_filename: string;
 	collection_id: number;
 	collection_title: string;
 	url_slug?: string;
@@ -32,7 +33,8 @@ export interface PlannedMeal {
 export interface Meal {
 	id: number;
 	name: string;
-	filename: string;
+	image_filename: string;
+	pdf_filename: string;
 	collection_id: number;
 	collection_title: string;
 	url_slug?: string;
@@ -42,7 +44,8 @@ export interface Meal {
 export interface Recipe {
 	id: number;
 	name: string;
-	filename: string;
+	image_filename: string;
+	pdf_filename: string;
 	prepTime?: number;
 	cookTime?: number;
 	cost?: number;
@@ -58,7 +61,8 @@ export interface Recipe {
 export interface RecipeDetail {
 	id: number;
 	name: string;
-	filename: string;
+	image_filename: string;
+	pdf_filename: string;
 	description: string;
 	prepTime?: number;
 	cookTime?: number;


### PR DESCRIPTION
## Summary
- Implements comprehensive recipe file versioning system to resolve browser caching issues
- Adds support for multiple image formats (JPG, PNG, WebP) with automatic cache busting
- Separates image and PDF filename handling for independent versioning

## Key Changes

### Database Schema
- **Migration 015**: Adds `image_filename` and `pdf_filename` columns to recipes table
- Migrates existing data from single `filename` column to separate fields
- Drops legacy `filename` column for cleaner schema

### File Versioning System
- **Cache Busting**: Implements versioned filenames with `_v1`, `_v2`, `_v3` suffixes
- **Multi-format Support**: Supports JPG, PNG, WebP image formats
- **Version Management**: Automatic version incrementing on file updates

### API Enhancements
- **update-image**: Enhanced with versioning and multi-format support
- **update-pdf**: New dedicated endpoint for PDF versioning
- **ai-import**: Updated to use new filename structure
- **File Upload APIs**: Maintains original behavior for new uploads

### Frontend Components
- Updated all recipe components to use separate image/PDF filenames
- Enhanced file upload workflows with proper version handling
- Improved type safety across all interfaces

### Technical Details
- **TypeScript**: Updated 4 core interfaces (`Recipe`, `RecipeDetail`, `Meal`, `PlannedMeal`)
- **Utilities**: New versioning functions in `secureFilename.ts`
- **Database Queries**: Updated all queries to use new column structure

## Problem Solved
Previously, when users updated recipe images or PDFs, browsers would cache the old files using the same URL. This implementation ensures that updated files get new URLs (e.g., `recipe_123.jpg` → `recipe_123_v2.jpg`), forcing browsers to fetch the latest content immediately.

## Testing
- ✅ All linting checks pass (`npm run lint`)
- ✅ Production build succeeds (`npm run build`)
- ✅ TypeScript compilation with no errors
- ✅ Database migration tested with data preservation

🤖 Generated with [Claude Code](https://claude.ai/code)