### PR TITLE
Fix: Display measurements next to quantities on recipe details page

### DIFF
--- a/src/lib/queries/menus.ts
+++ b/src/lib/queries/menus.ts
@@ -1040,7 +1040,7 @@ export async function getRecipeDetailsHousehold(id: string, householdId: number)
 							name: row.preperation_name,
 						}
 					: null,
-				quantityMeasure: row.measure_id
+				measure: row.measure_id
 					? {
 							id: row.measure_id,
 							name: row.measure_name,


### PR DESCRIPTION
## Summary
- Fixed missing measurement units (e.g., "cups", "tbsp") next to ingredient quantities on recipe details page
- Changed field name from `quantityMeasure` to `measure` in `getRecipeDetailsHousehold()` function

## Problem
The recipe details page was not displaying measurement units next to ingredient quantities. Users would see "2" instead of "2 cups" or "1" instead of "1 tbsp".

## Solution
The issue was in the `getRecipeDetailsHousehold()` function in `/src/lib/queries/menus.ts` where the measurement field was being named `quantityMeasure` instead of `measure`. The `IngredientsTable` component expects the field to be called `measure` to match the `RecipeIngredient` interface.

## Test plan
- [x] All existing tests pass (1058 tests)
- [x] Production build succeeds
- [ ] Navigate to any recipe details page
- [ ] Verify that measurements now appear next to quantities (e.g., "2 cups", "1 tbsp")
- [ ] Verify edit mode still works correctly for ingredients

🤖 Generated with [Claude Code](https://claude.ai/code)