### PR TITLE
Fix: Improve collections grid layout for extra-wide screens

### DIFF
--- a/src/app/recipes/collections-client.tsx
+++ b/src/app/recipes/collections-client.tsx
@@ -60,7 +60,7 @@ const CollectionsPageClient = ({ myCollections, publicCollections }: Collections
 			{/* My Collections Section */}
 			<section className="mb-12">
 				{myCollections.length > 0 ? (
-					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
 						{myCollections.map(collection => (
 							<div key={collection.id}>
 								{collection.access_type === 'owned' ? (
@@ -112,7 +112,7 @@ const CollectionsPageClient = ({ myCollections, publicCollections }: Collections
 				</div>
 
 				{publicCollections.length > 0 ? (
-					<div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+					<div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7 gap-4">
 						{publicCollections.map(collection => (
 							<div key={collection.id} className="relative">
 								{/* All collections should be clickable */}


### PR DESCRIPTION
## Summary
- Added xl breakpoint (1280px+) for better grid layout on extra-wide screens
- My Collections now shows 4 columns instead of 3 on xl screens
- Public Collections now shows 7 columns instead of 6 on xl screens

## Problem
On extra-wide browser windows, the collections grids looked too spread out:
- My Collections section was limited to 3 columns, leaving too much whitespace
- Public Collections section was limited to 6 columns when it could fit 7

## Solution
Added Tailwind's `xl:` breakpoint classes to both grid configurations:
- My Collections: `xl:grid-cols-4` (was: `lg:grid-cols-3`)
- Public Collections: `xl:grid-cols-7` (was: `lg:grid-cols-6`)

## Test plan
- [x] Build succeeds
- [x] View collections page on extra-wide screen (1280px+)
- [x] Verify My Collections shows 4 items per row
- [x] Verify Public Collections shows 7 items per row
- [x] Test responsive behavior at different breakpoints (md, lg, xl)
- [x] Ensure cards don't become too small or cramped

🤖 Generated with [Claude Code](https://claude.ai/code)