### PR TITLE
Fix recipe links to open in new tab during plan edit mode

### DIFF
--- a/src/app/components/RecipeCard.tsx
+++ b/src/app/components/RecipeCard.tsx
@@ -17,6 +17,7 @@ interface RecipeCardProps {
 	isSelecting?: boolean;
 	isSelected?: boolean;
 	onToggleSelection?: (recipeId: number) => void;
+	openInNewTab?: boolean;
 }
 
 const RecipeCard = ({
@@ -31,6 +32,7 @@ const RecipeCard = ({
 	isSelecting = false,
 	isSelected = false,
 	onToggleSelection,
+	openInNewTab = false,
 }: RecipeCardProps) => {
 	const [displayRecipe, setDisplayRecipe] = useState(recipe);
 	const [isFlipping, setIsFlipping] = useState(false);
@@ -195,7 +197,12 @@ const RecipeCard = ({
 					) : (
 						// Normal mode, render with links
 						<>
-							<Link href={generateRecipeUrl(displayRecipe)} className="block">
+							<Link
+								href={generateRecipeUrl(displayRecipe)}
+								className="block"
+								target={openInNewTab ? '_blank' : undefined}
+								rel={openInNewTab ? 'noopener noreferrer' : undefined}
+							>
 								<img
 									className="w-full aspect-square object-cover"
 									alt={`${name} recipe`}
@@ -207,7 +214,11 @@ const RecipeCard = ({
 							</Link>
 
 							<div className="p-4 flex flex-col flex-grow">
-								<Link href={generateRecipeUrl(displayRecipe)}>
+								<Link
+									href={generateRecipeUrl(displayRecipe)}
+									target={openInNewTab ? '_blank' : undefined}
+									rel={openInNewTab ? 'noopener noreferrer' : undefined}
+								>
 									<h3 className="text-lg text-foreground mb-2">{name}</h3>
 								</Link>
 

--- a/src/app/plan/components/RecipeGrid.tsx
+++ b/src/app/plan/components/RecipeGrid.tsx
@@ -31,6 +31,7 @@ export function RecipeGrid({ recipes, allRecipes, isEditMode, isLoading, recipeA
 						onRemoveRecipe={recipeActions.handleRemoveRecipe}
 						triggerAnimation={animatingAutomate}
 						newRecipe={newRecipe}
+						openInNewTab={isEditMode}
 					/>
 				);
 			})}


### PR DESCRIPTION
## Summary
Fixes the issue where clicking on recipe images or titles during meal plan editing would navigate away from the plan page, causing users to lose their edit state and unsaved changes.

## Problem
When in edit mode on the plan page:
- Users could accidentally click on recipe images/titles (missing the swap button)
- This would navigate to the recipe detail page
- Using browser back button would return to plan page but lose all edit state and unsaved changes

## Solution
Added an `openInNewTab` prop to the RecipeCard component that opens links in a new tab when in edit mode, preserving the plan page state.

## Changes
- ✅ Added `openInNewTab` prop to RecipeCard component
- ✅ Modified Link components to conditionally use `target="_blank"` and `rel="noopener noreferrer"`
- ✅ Updated RecipeGrid to pass `openInNewTab={isEditMode}` to RecipeCard
- ✅ Normal behavior (same tab) maintained for all other RecipeCard usage

## Testing
- All tests pass (1158 tests)
- Type checking passes
- Linting passes
- Build succeeds

## User Impact
Users can now safely browse recipe details while editing their meal plan without losing their progress. The recipe will open in a new tab, allowing them to reference it while continuing to edit their plan.

🤖 Generated with [Claude Code](https://claude.ai/code)