### PR TITLE
Fix duplicate protein/carb types in recipe randomization

### DIFF
--- a/src/lib/queries/menus.ts
+++ b/src/lib/queries/menus.ts
@@ -157,6 +157,8 @@ interface RecipeRow {
 	collection_title: string;
 	collection_url_slug?: string;
 	seasonName?: string;
+	primaryTypeName?: string;
+	secondaryTypeName?: string;
 	ingredients?: string;
 	household_id: number;
 }
@@ -776,12 +778,16 @@ export async function getAllRecipesWithDetailsHousehold(householdId: number, col
 			c.title as collection_title,
 			c.url_slug as collection_url_slug,
 			s.name as seasonName,
+			pt.name as primaryTypeName,
+			st.name as secondaryTypeName,
 			GROUP_CONCAT(DISTINCT i.name SEPARATOR ', ') as ingredients
 		FROM recipes r
 		INNER JOIN collection_recipes cr ON r.id = cr.recipe_id
 		INNER JOIN collections c ON cr.collection_id = c.id
 		LEFT JOIN collection_subscriptions cs ON c.id = cs.collection_id AND cs.household_id = ?
 		LEFT JOIN seasons s ON r.season_id = s.id
+		LEFT JOIN type_proteins pt ON r.primaryType_id = pt.id
+		LEFT JOIN type_carbs st ON r.secondaryType_id = st.id
 		LEFT JOIN recipe_ingredients ri ON r.id = ri.recipe_id
 		LEFT JOIN ingredients i ON ri.ingredient_id = i.id
 		WHERE r.archived = 0
@@ -798,7 +804,7 @@ export async function getAllRecipesWithDetailsHousehold(householdId: number, col
 		params.push(collectionId);
 	}
 
-	query += ` GROUP BY r.id, r.name, r.image_filename, r.pdf_filename, r.prepTime, r.cookTime, r.description, r.url_slug, r.household_id, cr.collection_id, c.title, c.url_slug, s.name
+	query += ` GROUP BY r.id, r.name, r.image_filename, r.pdf_filename, r.prepTime, r.cookTime, r.description, r.url_slug, r.household_id, cr.collection_id, c.title, c.url_slug, s.name, pt.name, st.name
 		ORDER BY r.name ASC`;
 
 	const [rows] = await pool.execute(query, params);


### PR DESCRIPTION
## Summary

Fixes the SQL query in `getAllRecipesWithDetailsHousehold` to include protein and carb type names, enabling the progressive filtering algorithm in `selectRandomRecipes` to properly prevent duplicate protein/carb types in meal plans.

### Problem

When clicking "Plan for Me" repeatedly, users were seeing duplicate protein types (e.g., 2x Chicken) and carb types (e.g., 2x Rice) in a single meal plan. 

**Root Cause**: The `getAllRecipesWithDetailsHousehold` SQL query was missing JOINs to the `type_proteins` and `type_carbs` tables, causing `primaryTypeName` and `secondaryTypeName` to be `undefined` for all recipes in `allRecipes`. The progressive filtering algorithm in `selectRandomRecipes` relies on these fields to filter out recipes with duplicate types.

### Solution

Updated the SQL query to:
- Add `LEFT JOIN` to `type_proteins` and `type_carbs` tables
- Include `pt.name as primaryTypeName` and `st.name as secondaryTypeName` in SELECT clause
- Add `pt.name, st.name` to GROUP BY clause
- Update `RecipeRow` interface to include these fields

This matches the pattern already used in `getRecipeDetailsHousehold`.

### Changes

**Modified Files:**
- `src/lib/queries/menus.ts` - Updated `getAllRecipesWithDetailsHousehold` query and `RecipeRow` interface

### Testing

- [x] Type check passes (`npm run type`)
- [x] Lint passes (`npm run lint`)
- [x] All 1152 tests pass (`npm run test`)
- [x] Production build succeeds (`npm run build`)
- [x] Manual test: Click "Plan for Me" multiple times and verify no duplicate protein/carb types appear in a single plan

### Impact

The progressive filtering algorithm now works as designed:
1. Select random recipe with Chicken/Rice
2. Filter out ALL recipes with Chicken OR Rice
3. Select next random recipe from remaining pool
4. Continue until desired count reached

This ensures variety in meal plans with no duplicate protein or carb types within a single week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)